### PR TITLE
fix: 1、当配置面板处于高级、数据和联动tab时，切换设计区内的组件或者拖拽进来一个新组件，面板不会更新渲染.

### DIFF
--- a/src/pages/designer/canvas-graph/index.js
+++ b/src/pages/designer/canvas-graph/index.js
@@ -85,7 +85,7 @@ function Wrapper(props, ref) {
           configs.data.top = event.nativeEvent.offsetY - configs.data.height / 2;
 
           const { components, fieldId } = generatorField(state.components, "field", configs);
-          setState({ tabsKey: "base", components: components });
+          setState({ tabsKey: state.tabsKey || "base", components: components });
           props.dispatch({ type: "component/selected", data: fieldId });
         }
       } catch (error) {

--- a/src/pages/designer/renderer/core.js
+++ b/src/pages/designer/renderer/core.js
@@ -39,7 +39,7 @@ function DragField({ value, tabBind, tabStore, selected, dispatch, onValueChange
   const { width, height, background, left, top, isHidden, isLock, ...rest } = value.data;
   const [locations, setLocations] = useState({ left: left, top: top });
   const [show, setShow] = useState(true);
-  const { setState } = useDesigner();
+  const { state, setState } = useDesigner();
   const { view } = useView();
 
   const classNames = cx("drag-shape-wrap animate__animated", {
@@ -96,8 +96,7 @@ function DragField({ value, tabBind, tabStore, selected, dispatch, onValueChange
     ev.preventDefault();
     ev.stopPropagation();
     if (hasSelected) return;
-
-    setState({ tabsKey: "base" });
+    setState({ tabsKey: state.tabsKey || "base" });
     // TODO: 获取当前用户点击的key
     dispatch({ type: "component/selected", data: value.uniqueId });
   };

--- a/src/pages/designer/toollbar/header.js
+++ b/src/pages/designer/toollbar/header.js
@@ -27,6 +27,7 @@ const FieldActionsConf = ({ selected, dispatch }) => {
       }
     });
     setState({
+      tabsKey: 'base',
       components: [],
       undo: [],
       redo: []


### PR DESCRIPTION
fix: 2、清空设计区时，同时也需要重置tabsKey，否则会导致后续拖拽进来的新组件配置面板异常